### PR TITLE
Optionally disable python zipfile

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -632,6 +632,7 @@ def main():
             copy              = dict(default=True, type='bool'),
             creates           = dict(required=False, type='path'),
             list_files        = dict(required=False, default=False, type='bool'),
+            # Adding support_legacy as a quick-and-dirty fix for issue #3560
             support_legacy    = dict(required=False, default=False, type='bool'),
             keep_newer        = dict(required=False, default=False, type='bool'),
             exclude           = dict(requited=False, default=[], type='list'),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

unarchive
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /opt/ansible/sysadmin/ansible.cfg
  configured module search path = /usr/share/ansible/
```
##### SUMMARY

A quick-and-dirty way of resolving #3560 is to simply disable any calls to the ZipFile module, based upon an optional parameter that defaults to not doing anything.

This pull request adds a `support_legacy` parameter that defaults to no, but when set to yes, the unarchive module no longer calls the ZipFile module.

Did I mention this is quick-and-dirty?
